### PR TITLE
Updated grayscale.js

### DIFF
--- a/js/grayscale.js
+++ b/js/grayscale.js
@@ -34,12 +34,6 @@ $('.navbar-collapse ul li a').click(function() {
 
 // Google Maps Scripts
 var map = null;
-// When the window has finished loading create our google map below
-google.maps.event.addDomListener(window, 'load', init);
-google.maps.event.addDomListener(window, 'resize', function() {
-    map.setCenter(new google.maps.LatLng(40.6700, -73.9400));
-});
-
 function init() {
     // Basic options for a simple Google Map
     // For more options see: https://developers.google.com/maps/documentation/javascript/reference#MapOptions
@@ -182,4 +176,11 @@ function init() {
         map: map,
         icon: image
     });
+    
+    // When the window has finished loading create our google map below
+    google.maps.event.addDomListener(window, 'load', init);
+    google.maps.event.addDomListener(window, 'resize', function() {
+        map.setCenter(new google.maps.LatLng(40.6700, -73.9400));
+    });
+
 }


### PR DESCRIPTION

Moved the two `google.maps.event.addDomListener` at the end of `initMap()` since deferred loading of the map API could cause `google `not to be defined yet, resulting in `Uncaught ReferenceError: google is not defined` error.

![screen1](https://cloud.githubusercontent.com/assets/22095380/23173111/58303324-f858-11e6-871c-022ec2e9927a.PNG)